### PR TITLE
optimized code to work with large dataset.

### DIFF
--- a/R/OneR_main.R
+++ b/R/OneR_main.R
@@ -56,10 +56,10 @@ OneR <- function(data, formula = NULL, ties.method = c("first", "chisq"), verbos
   # main routine
   perf <- c()
   for (iter in 1:(ncol(data) - 1)) {
-    groups <- split(data, data[ , iter])
-    majority <- lapply(groups, mode)
-    real <- lapply(groups, function(x) x[ , ncol(x)])
-    perf <- c(perf, sum(unlist(Map("==", real, majority))))
+    groups <- split(data[,ncol(data)], data[, iter])
+    mapping <- lapply(groups, function(x)names(sort(-table(x)))[1])
+    pred <- unlist(mapping)[data[,iter]]
+    perf <- c(perf, sum(data[,ncol(data)]==pred))
   }
   target <- names(data[ , ncol(data), drop = FALSE])
   best <- which(perf == max(perf))
@@ -72,8 +72,8 @@ OneR <- function(data, formula = NULL, ties.method = c("first", "chisq"), verbos
       best <- best[which.min(p.values)]
     } else best <- best[1]
   }
-  groups <- split(data, data[ , best])
-  majority <- lapply(groups, mode)
+  groups <- split(data[,ncol(data)], data[ , best])
+  majority <- lapply(groups, function(x)names(sort(-table(x)))[1])
   feature <- names(data[ , best, drop = FALSE])
   cont_table <- table(c(data[target], data[feature]))
   output <- c(call = call,


### PR DESCRIPTION
Hi there,
thanks for the package!
I recently applied it to my large-ish dataset (2k rows, 1k cols) and it was quite slow.
I tracked the slowness to 2 issues.
1. `split(data, data[,iter])` can be quite slow when `data` is large, so I replaced it with `split(data[,ncol(data)],data[,iter])`, as we only need the response column for the split.
2. `sum(unlist(Map("==", real, majority))` is quite slow again, so I replaced it by codes which first form the entire vector of predicted value (not in groups), then compared it directly against `data[,ncol(data)]`.

This new code took 0.7s on my dataset, while the old code took 66s (almost a 100x speed up).